### PR TITLE
Use UTF-8 for German localization

### DIFF
--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -2,6 +2,6 @@
 $messages = array();
 $messages['alias'] = 'alias';
 $messages['sigvalid'] = 'Digital unterschrieben von $sender. Das Zertifikat wurde von $issuer ausgegeben.';
-$messages['sigunverified'] = 'Digital unterschrieben von $sender. Das von $issuer herausgegebene Zertifikat konnte nicht überprüft werden.';
-$messages['siginvalid'] = 'Ungültige digitale Unterschrift.';
+$messages['sigunverified'] = 'Digital unterschrieben von $sender. Das von $issuer herausgegebene Zertifikat konnte nicht Ã¼berprÃ¼ft werden.';
+$messages['siginvalid'] = 'UngÃ¼ltige digitale Unterschrift.';
 ?>


### PR DESCRIPTION
Without this, the umlauts in error messages are garbled.