### PR TITLE
Small bugfix

### DIFF
--- a/rc_smime.php
+++ b/rc_smime.php
@@ -194,8 +194,10 @@ class rc_smime extends rcube_plugin
                 }
             }
 
-            if (count($out['error']) == 0) {
-                unset($out['error']);
+            if (is_countable($out['error'])) {
+                if (count($out['error']) == 0) {
+                    unset($out['error']);
+                }
             }
 
             unlink($full_file);


### PR DESCRIPTION
Added smallest change needed to get this working with roundcube 1.5-rc1 and php 8.0.8

There may be other gotchas but haven't encountered them on my personal email server.

Otherwise trying to open emails causes a stack trace due to `count(null)` I think (I'm not a php pro):

```
[27-Jul-2021 14:05:37 UTC] PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable|array, null given in /var/www/html/plugins/rc_smime/rc_smime.php:197
Stack trace:
#0 /var/www/html/plugins/rc_smime/rc_smime.php(117): rc_smime->parse_smime_signed(Array)
#1 /var/www/html/plugins/rc_smime/rc_smime.php(103): rc_smime->parse_signed(Array)
#2 /var/www/html/program/lib/Roundcube/rcube_plugin_api.php(513): rc_smime->message_part_structure_hook(Array)
#3 /var/www/html/program/lib/Roundcube/rcube_message.php(646): rcube_plugin_api->exec_hook('message_part_st...', Array)
#4 /var/www/html/program/lib/Roundcube/rcube_message.php(131): rcube_message->parse_structure(Object(rcube_message_part))
#5 /var/www/html/program/actions/mail/show.php(63): rcube_message->__construct('xxxxx', 'xxxxx', false)
#6 /var/www/html/program/include/rcmail.php(275): rcmail_action_mail_show->run(Array)
#7 /var/www/html/index.php(283): rcmail->action_handler()
#8 {main}
  thrown in /var/www/html/plugins/rc_smime/rc_smime.php on line 197
``` 